### PR TITLE
Wip tune sharded bucket listing

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7931,15 +7931,7 @@ int RGWRados::cls_obj_set_bucket_tag_timeout(RGWBucketInfo& bucket_info, uint64_
 uint32_t RGWRados::calc_ordered_bucket_list_per_shard(uint32_t num_entries,
 						      uint32_t num_shards)
 {
-  constexpr uint32_t min_read = 8;
-  constexpr double excess_factor = 0.1; // read 10% extra
-
-  const uint32_t safety_per_shard =
-    uint32_t((1.0 + excess_factor) * num_entries / num_shards);
-  const uint32_t goal_per_shard = std::min(num_entries, safety_per_shard);
-  const uint32_t num_entries_per_shard = std::max(goal_per_shard, min_read);
-
-  return num_entries_per_shard;
+  return static_cast<uint32_t>((1.0 * num_entries / num_shards) + sqrt(2.0 * num_entries*log(num_shards)/num_shards) + 1);
 }
 
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1492,6 +1492,12 @@ public:
                    bool *is_truncated, RGWAccessListFilter *filter);
 
   uint64_t next_bucket_id();
+
+  /**
+   * This is broken out to facilitate unit testing.
+   */
+  static uint32_t calc_ordered_bucket_list_per_shard(uint32_t num_entries,
+						     uint32_t num_shards);
 };
 
 #endif


### PR DESCRIPTION
This PR improves performance over the base wip-tune-sharde-bucket-listing branch in two ways:

A) When iterating through the bucket list, some shards will eventually have fewer than entries_per_shard entries left.  This will cause the current listing code to stop working through the current page and start a new one on the assumption that more entries may be available in the future.  This commit adds tracking so that we know when no additional entries can be returned per shard and instead of giving up simply removes the shard from the candidates list.  If that shard could potentially have more entries, we revert to the existing behavior.

B) The next commit estimates the maximum number of entries per shard based on the normal distribution using the max formula from "Balls into Bins" -- A simple and Tight Analysis by Martin Raab and Angelika Steger:

http://www.dblab.ntua.gr/~gtsat/collection/scheduling/Balls%20into%20Bins%20A%20Simple%20and%20Tight%20Anal.pdf